### PR TITLE
Add support for cwd option

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function VFile(options) {
   this.data = {};
   this.messages = [];
   this.history = [];
-  this.cwd = process.cwd();
+  this.cwd = options.cwd || process.cwd();
 
   /* Set path related properties in the correct order. */
   index = -1;


### PR DESCRIPTION
Creating a VFile instance with a custom value for cwd should be possible according to the docs, however the value for process.cwd() is always used.  This allows for passing in your own value in the constructor.