### PR TITLE
Allow message.fatal to be null

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var proto = VFile.prototype;
 
 proto.toString = toString;
 proto.message = message;
+proto.info = info;
 proto.fail = fail;
 
 /* Slight backwards compatibility.  Remove in the future. */
@@ -153,8 +154,8 @@ function toString(encoding) {
 }
 
 /* Create a message with `reason` at `position`.
- * When an error is passed in as `reason`, copies the
- * stack.  This does not add a message to `messages`. */
+ * When an error is passed in as `reason`, copies the stack.
+ * Errors are not added as a message to `messages`. */
 function message(reason, position, ruleId) {
   var filePath = this.path;
   var range = stringify(position) || '1:1';
@@ -210,6 +211,16 @@ function fail() {
   message.fatal = true;
 
   throw message;
+}
+
+/* Info. Creates a vmessage, associates it with the file,
+ * and marks the fatality as null. */
+function info() {
+  var message = this.message.apply(this, arguments);
+
+  message.fatal = null;
+
+  return message;
 }
 
 /* Inherit from `Error#`. */

--- a/index.js
+++ b/index.js
@@ -154,8 +154,7 @@ function toString(encoding) {
 }
 
 /* Create a message with `reason` at `position`.
- * When an error is passed in as `reason`, copies the stack.
- * Errors are not added as a message to `messages`. */
+ * When an error is passed in as `reason`, copies the stack. */
 function message(reason, position, ruleId) {
   var filePath = this.path;
   var range = stringify(position) || '1:1';

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ npm install vfile
     *   [vfile.data](#vfiledata)
     *   [VFile#toString(\[encoding\])](#vfiletostringencoding)
     *   [VFile#message(reason\[, position\[, ruleId\]\])](#vfilemessagereason-position-ruleid)
+    *   [VFile#info(reason\[, position\[, ruleId\]\])](#vfileinforeason-position-ruleid)
     *   [VFile#fail(reason\[, position\[, ruleId\]\])](#vfilefailreason-position-ruleid)
     *   [VFileMessage](#vfilemessage)
 *   [License](#license)
@@ -206,7 +207,8 @@ Convert contents of `vfile` to string.  If `contents` is a buffer,
 ### `VFile#message(reason[, position[, ruleId]])`
 
 Associates a message with the file for `reason` at `position`.  When an
-error is passed in as `reason`, copies the stack.
+error is passed in as `reason`, copies the stack.  Each message has a `fatal`
+property which by default is set to `false` (ie. `warning`).
 
 ###### Parameters
 
@@ -215,7 +217,24 @@ error is passed in as `reason`, copies the stack.
 *   `position` (`Node`, `Location`, or `Position`, optional)
     — Place at which the message occurred in `vfile`
 *   `ruleId` (`string`, optional)
-    — Category of warning
+    — Category of message
+
+###### Returns
+
+[`VFileMessage`][message].
+
+### `VFile#info(reason[, position[, ruleId]])`
+
+Associates a message with the file, where `fatal` is set to `null`.
+
+###### Parameters
+
+*   `reason` (`string` or `Error`)
+    — Reason for message, uses the stack and message of the error if given
+*   `position` (`Node`, `Location`, or `Position`, optional)
+    — Place at which the message occurred in `vfile`
+*   `ruleId` (`string`, optional)
+    — Category of message
 
 ###### Returns
 

--- a/test.js
+++ b/test.js
@@ -502,6 +502,32 @@ test('vfile([options])', function (t) {
     st.end();
   });
 
+  t.test('#info(reason[, position[, ruleId]])', function (st) {
+    var file = vfile({path: '~/example.md'});
+    var message;
+
+    file.info('Bar', {line: 1, column: 3}, 'baz');
+
+    st.equal(file.messages.length, 1);
+
+    message = file.messages[0];
+
+    st.equal(message.name, '~/example.md:1:3');
+    st.equal(message.file, '~/example.md');
+    st.equal(message.reason, 'Bar');
+    st.equal(message.ruleId, 'baz');
+    st.equal(message.source, null);
+    st.equal(message.fatal, null);
+    st.equal(message.line, 1);
+    st.equal(message.column, 3);
+    st.deepEqual(message.location, {
+      start: {line: 1, column: 3},
+      end: {line: null, column: null}
+    });
+
+    st.end();
+  });
+
   t.end();
 });
 


### PR DESCRIPTION
Based off #17, this allows a user to create a message that has the indeterminate fatal value of `null`. 