### PR TITLE
Remove process.cwd

### DIFF
--- a/core.js
+++ b/core.js
@@ -44,7 +44,6 @@ function VFile(options) {
   this.data = {};
   this.messages = [];
   this.history = [];
-  this.cwd = process.cwd();
 
   /* Set path related properties in the correct order. */
   index = -1;


### PR DESCRIPTION
This breaks react-native and isn't being used

<!--

Read the [contributing guidelines](https://github.com/vfile/vfile/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
