### PR TITLE
test: cleanup type tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "remark-preset-wooorm": "^6.0.0",
     "tape": "^4.0.0",
     "tinyify": "^2.0.0",
-    "typescript": "^3.0.0",
     "xo": "^0.25.0"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # [![vfile][]][unified]
 
+[![GitHub CI][github-ci-badge]][github-ci]
 [![Build][build-badge]][build]
 [![Coverage][coverage-badge]][coverage]
 [![Downloads][downloads-badge]][downloads]
@@ -340,6 +341,10 @@ for contributing commits since!
 [MIT][license] © [Titus Wormer][author]
 
 <!-- Definitions -->
+
+[github-ci-badge]: https://github.com/vfile/vfile/workflows/CI/badge.svg
+
+[github-ci]: https://github.com/vfile/vfile/actions
 
 [build-badge]: https://img.shields.io/travis/vfile/vfile.svg
 

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,10 +2,6 @@
   "compilerOptions": {
     "lib": ["es2015"],
     "strict": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
     "baseUrl": ".",
     "paths": {
       "vfile": ["index.d.ts"]

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,14 +1,7 @@
 {
   "extends": "dtslint/dtslint.json",
   "rules": {
-    "callable-types": false,
-    "max-line-length": false,
-    "no-redundant-jsdoc": false,
-    "no-void-expression": false,
-    "only-arrow-functions": false,
     "semicolon": false,
-    "unified-signatures": false,
-    "whitespace": false,
-    "interface-over-type-literal": false
+    "whitespace": false
   }
 }


### PR DESCRIPTION
remove compiler options covered by strict.
remove disables for rules that aren't warning.
add github ci badge.
remove unneeded typescript dependency, dtslint downloads several typescript versions for testing.

