### PR TITLE
types: make the VFile contents field parametric

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,10 +5,13 @@ import * as vfileMessage from 'vfile-message'
 
 declare namespace vfile {
   type VFileContents = string | Buffer
-  type VFileCompatible = VFile | VFileOptions | VFileContents
+  type VFileCompatible<Contents = VFileContents> =
+    | VFile<Contents>
+    | VFileOptions<Contents>
+    | Contents
 
-  interface VFileOptions {
-    contents?: VFileContents
+  interface VFileOptions<Contents = VFileContents> {
+    contents?: Contents
     path?: string
     basename?: string
     stem?: string
@@ -19,7 +22,7 @@ declare namespace vfile {
     [key: string]: any
   }
 
-  interface VFile {
+  interface VFile<Contents = VFileContents> {
     /**
      * Create a new virtual file. If `options` is `string` or `Buffer`, treats it as `{contents: options}`.
      * If `options` is a `VFile`, returns it. All other options are set on the newly created `vfile`.
@@ -30,7 +33,9 @@ declare namespace vfile {
      *
      * @param options If `options` is `string` or `Buffer`, treats it as `{contents: options}`. If `options` is a `VFile`, returns it. All other options are set on the newly created `vfile`.
      */
-    <F extends VFile>(input?: VFileContents | F | VFileOptions): F
+    <C = VFileContents, F extends VFile<C> = VFile<C>>(
+      input?: (C extends VFileContents ? VFileContents : never) | F | VFileOptions<C>
+    ): F
     /**
      * List of file-paths the file moved between.
      */
@@ -47,7 +52,7 @@ declare namespace vfile {
     /**
      * Raw value.
      */
-    contents: VFileContents
+    contents: Contents
     /**
      * Path of `vfile`.
      * Cannot be nullified.

--- a/types/vfile-tests.ts
+++ b/types/vfile-tests.ts
@@ -78,7 +78,7 @@ interface CustomVFile extends vfile.VFile {
   }
 }
 
-const customVFile = vfile<CustomVFile>({
+const customVFile = vfile<CustomVFile["contents"], CustomVFile>({
   path: '~/example.txt',
   contents: 'Alpha *braavo* charlie.',
   custom: 'Custom tango',
@@ -91,3 +91,23 @@ customVFile.custom = 'test'
 customVFile.data.custom = 1234
 
 const copiedFile: CustomVFile = vfile(customVFile)
+
+interface CustomContent {
+  foo: string
+}
+
+const customContentVFile = vfile<CustomContent>({
+  contents: {
+    foo: 'bar'
+  }
+})
+customContentVFile.contents.foo = 'baz'
+customContentVFile.contents.baz = 'foobar' // $ExpectError
+
+const invalidContent = {contents: {baz: 'foobar'}}
+vfile<CustomContent>(invalidContent) // $ExpectError
+
+const testContentsType = vfile('foo')
+testContentsType.contents.baz = 'foobar' // $ExpectError
+
+vfile<CustomContent>('foo'); // $ExpectError


### PR DESCRIPTION
This makes the `contents` field on the `VFile` type parametric.

Breaking change: before this, the vfile function had only one type parameter, a custom VFile type. This introduces another one which is placed before it.

Before:
```ts
vfile<CustomVFile>(...);
```
After:

```ts
vfile<CustomVFile["contents"], CustomVFile>(...); // or
vfile<vfile.VFileContents, CustomVFile>(...);
```

I don't think it will break a lot of projects (not sure if a lot of people are using custom VFiles & typescript) ; but this may require a major version bump because of this.

Closes GH-45