### PR TITLE
types: replace node Buffer and BufferEncoding types with browser compatible types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,9 +5,18 @@ import * as vfileMessage from 'vfile-message'
 
 declare namespace vfile {
   /**
-   * VFileContents can either be text, or a `Buffer`-like structure
+   * Encodings supported by the buffer class
+   * 
    * @remarks
-   * This does not directly use type `Buffer`, because it can also be used in a browser context.
+   * This is a copy of the typing from Node, copied to prevent Node globals from being needed.
+   * Copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2bc1d868d81733a8969236655fa600bd3651a7b/types/node/globals.d.ts#L174
+   */
+  type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
+
+  /**
+   * VFileContents can either be text, or a Buffer like structure
+   * @remarks
+   * This does not directly use type `Buffer, because it can also be used in a browser context.
    * Instead this leverages `Uint8Array` which is the base type for `Buffer`, and a native JavaScript construct.
    */
   type VFileContents = string | Uint8Array
@@ -92,11 +101,8 @@ declare namespace vfile {
     /**
      * Convert contents of `vfile` to string.
      * @param encoding If `contents` is a buffer, `encoding` is used to stringify buffers (default: `'utf8'`).
-     * @remarks
-     * This can also be used in a browser context, this accepts the same values as Node's `BufferEncoding`,
-     * but does not directly reference the type for compatibility.
      */
-    toString: (encoding?: string) => string
+    toString: (encoding?: BufferEncoding) => string
     /**
      * Associates a message with the file for `reason` at `position`.
      * When an error is passed in as `reason`, copies the stack.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,15 +5,12 @@ import * as vfileMessage from 'vfile-message'
 
 declare namespace vfile {
   /**
-   * Type must have the same base as Node.js Buffer
+   * VFileContents can either be text, or a `Buffer`-like structure
+   * @remarks
+   * This does not directly use type `Buffer`, because it can also be used in a browser context.
+   * Instead this leverages `Uint8Array` which is the base type for `Buffer`, and a native JavaScript construct.
    */
-  type BufferLike = Uint8Array
-  /**
-   * Type must have same base as Node.js BufferEncoding
-   */
-  type BufferEncodingLike = string
-
-  type VFileContents = string | BufferLike
+  type VFileContents = string | Uint8Array
   type VFileCompatible = VFile | VFileOptions | VFileContents
   interface Settings {
     [key: string]: unknown
@@ -95,8 +92,11 @@ declare namespace vfile {
     /**
      * Convert contents of `vfile` to string.
      * @param encoding If `contents` is a buffer, `encoding` is used to stringify buffers (default: `'utf8'`).
+     * @remarks
+     * This can also be used in a browser context, this accepts the same values as Node's `BufferEncoding`,
+     * but does not directly reference the type for compatibility.
      */
-    toString: (encoding?: BufferEncodingLike) => string
+    toString: (encoding?: string) => string
     /**
      * Associates a message with the file for `reason` at `position`.
      * When an error is passed in as `reason`, copies the stack.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,16 @@ import * as Unist from 'unist'
 import * as vfileMessage from 'vfile-message'
 
 declare namespace vfile {
-  type VFileContents = string | Buffer
+  /**
+   * Type must have the same base as Node.js Buffer
+   */
+  type BufferLike = Uint8Array
+  /**
+   * Type must have same base as Node.js BufferEncoding
+   */
+  type BufferEncodingLike = string
+
+  type VFileContents = string | BufferLike
   type VFileCompatible = VFile | VFileOptions | VFileContents
   interface Settings {
     [key: string]: unknown
@@ -87,7 +96,7 @@ declare namespace vfile {
      * Convert contents of `vfile` to string.
      * @param encoding If `contents` is a buffer, `encoding` is used to stringify buffers (default: `'utf8'`).
      */
-    toString: (encoding?: BufferEncoding) => string
+    toString: (encoding?: BufferEncodingLike) => string
     /**
      * Associates a message with the file for `reason` at `position`.
      * When an error is passed in as `reason`, copies the stack.


### PR DESCRIPTION
resolves https://github.com/unifiedjs/unified/issues/45#issuecomment-470799585
without needing to move all types to `devDependencies`, based on suggestion https://github.com/unifiedjs/unified/issues/45#issuecomment-621380700