### PR TITLE
require process rather than using global

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var path = require('path')
+var process = require('process')
 var replace = require('replace-ext')
 var buffer = require('is-buffer')
 


### PR DESCRIPTION
Hello maintainers!

First of all, thanks for working on vfile, I've been using this a lot (especially with remark) and it's been a lifesaver.

tl;dr, webpack versions 1-4 used to automatically polyfill node.js libraries and the next version, version 5, doesn't.

While migrating a larger project of mine, I ran into a scenario where vfile was breaking because it wasn't loading my `process` polyfill because `vfile` is using `process` as a global.

Here is the related webpack issue: https://github.com/webpack/webpack/issues/11282