### PR TITLE
Add manual browser polyfills for path, process

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,7 +1,7 @@
 'use strict'
 
-var path = require('path')
-var replace = require('replace-ext')
+var p = require('./minpath')
+var proc = require('./minproc')
 var buffer = require('is-buffer')
 
 module.exports = VFile
@@ -59,7 +59,7 @@ function VFile(options) {
   this.data = {}
   this.messages = []
   this.history = []
-  this.cwd = process.cwd()
+  this.cwd = proc.cwd()
 
   // Set path related properties in the correct order.
   index = -1
@@ -93,26 +93,26 @@ function setPath(path) {
 }
 
 function getDirname() {
-  return typeof this.path === 'string' ? path.dirname(this.path) : undefined
+  return typeof this.path === 'string' ? p.dirname(this.path) : undefined
 }
 
 function setDirname(dirname) {
   assertPath(this.path, 'dirname')
-  this.path = path.join(dirname || '', this.basename)
+  this.path = p.join(dirname || '', this.basename)
 }
 
 function getBasename() {
-  return typeof this.path === 'string' ? path.basename(this.path) : undefined
+  return typeof this.path === 'string' ? p.basename(this.path) : undefined
 }
 
 function setBasename(basename) {
   assertNonEmpty(basename, 'basename')
   assertPart(basename, 'basename')
-  this.path = path.join(this.dirname || '', basename)
+  this.path = p.join(this.dirname || '', basename)
 }
 
 function getExtname() {
-  return typeof this.path === 'string' ? path.extname(this.path) : undefined
+  return typeof this.path === 'string' ? p.extname(this.path) : undefined
 }
 
 function setExtname(extname) {
@@ -129,19 +129,19 @@ function setExtname(extname) {
     }
   }
 
-  this.path = replace(this.path, extname || '')
+  this.path = p.join(this.dirname, this.stem + (extname || ''))
 }
 
 function getStem() {
   return typeof this.path === 'string'
-    ? path.basename(this.path, this.extname)
+    ? p.basename(this.path, this.extname)
     : undefined
 }
 
 function setStem(stem) {
   assertNonEmpty(stem, 'stem')
   assertPart(stem, 'stem')
-  this.path = path.join(this.dirname || '', stem + (this.extname || ''))
+  this.path = p.join(this.dirname || '', stem + (this.extname || ''))
 }
 
 // Get the value of the file.
@@ -149,11 +149,11 @@ function toString(encoding) {
   return (this.contents || '').toString(encoding)
 }
 
-// Assert that `part` is not a path (i.e., does not contain `path.sep`).
+// Assert that `part` is not a path (i.e., does not contain `p.sep`).
 function assertPart(part, name) {
-  if (part && part.indexOf(path.sep) > -1) {
+  if (part && part.indexOf(p.sep) > -1) {
     throw new Error(
-      '`' + name + '` cannot be a path: did not expect `' + path.sep + '`'
+      '`' + name + '` cannot be a path: did not expect `' + p.sep + '`'
     )
   }
 }

--- a/minpath.browser.js
+++ b/minpath.browser.js
@@ -1,0 +1,374 @@
+'use strict'
+
+// A derivative work based on:
+// <https://github.com/browserify/path-browserify>.
+// Which is licensed:
+//
+// MIT License
+//
+// Copyright (c) 2013 James Halliday
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// A derivative work based on:
+//
+// Parts of that are extracted from Node’s internal `path` module:
+// <https://github.com/nodejs/node/blob/master/lib/path.js>.
+// Which is licensed:
+//
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.basename = basename
+exports.dirname = dirname
+exports.extname = extname
+exports.join = join
+exports.sep = '/'
+
+function basename(path, ext) {
+  var start = 0
+  var end = -1
+  var index
+  var firstNonSlashEnd
+  var seenNonSlash
+  var extIndex
+
+  if (ext !== undefined && typeof ext !== 'string') {
+    throw new TypeError('"ext" argument must be a string')
+  }
+
+  assertPath(path)
+  index = path.length
+
+  if (ext === undefined || !ext.length || ext.length > path.length) {
+    while (index--) {
+      if (path.charCodeAt(index) === 47 /* `/` */) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now.
+        if (seenNonSlash) {
+          start = index + 1
+          break
+        }
+      } else if (end < 0) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component.
+        seenNonSlash = true
+        end = index + 1
+      }
+    }
+
+    return end < 0 ? '' : path.slice(start, end)
+  }
+
+  if (ext === path) {
+    return ''
+  }
+
+  firstNonSlashEnd = -1
+  extIndex = ext.length - 1
+
+  while (index--) {
+    if (path.charCodeAt(index) === 47 /* `/` */) {
+      // If we reached a path separator that was not part of a set of path
+      // separators at the end of the string, stop now.
+      if (seenNonSlash) {
+        start = index + 1
+        break
+      }
+    } else {
+      if (firstNonSlashEnd < 0) {
+        // We saw the first non-path separator, remember this index in case
+        // we need it if the extension ends up not matching.
+        seenNonSlash = true
+        firstNonSlashEnd = index + 1
+      }
+
+      if (extIndex > -1) {
+        // Try to match the explicit extension.
+        if (path.charCodeAt(index) === ext.charCodeAt(extIndex--)) {
+          if (extIndex < 0) {
+            // We matched the extension, so mark this as the end of our path
+            // component
+            end = index
+          }
+        } else {
+          // Extension does not match, so our result is the entire path
+          // component
+          extIndex = -1
+          end = firstNonSlashEnd
+        }
+      }
+    }
+  }
+
+  if (start === end) {
+    end = firstNonSlashEnd
+  } else if (end < 0) {
+    end = path.length
+  }
+
+  return path.slice(start, end)
+}
+
+function dirname(path) {
+  var end
+  var unmatchedSlash
+  var index
+
+  assertPath(path)
+
+  if (!path.length) {
+    return '.'
+  }
+
+  end = -1
+  index = path.length
+
+  // Prefix `--` is important to not run on `0`.
+  while (--index) {
+    if (path.charCodeAt(index) === 47 /* `/` */) {
+      if (unmatchedSlash) {
+        end = index
+        break
+      }
+    } else if (!unmatchedSlash) {
+      // We saw the first non-path separator
+      unmatchedSlash = true
+    }
+  }
+
+  return end < 0
+    ? path.charCodeAt(0) === 47 /* `/` */
+      ? '/'
+      : '.'
+    : end === 1 && path.charCodeAt(0) === 47 /* `/` */
+    ? '//'
+    : path.slice(0, end)
+}
+
+function extname(path) {
+  var startDot = -1
+  var startPart = 0
+  var end = -1
+  // Track the state of characters (if any) we see before our first dot and
+  // after any path separator we find.
+  var preDotState = 0
+  var unmatchedSlash
+  var code
+  var index
+
+  assertPath(path)
+
+  index = path.length
+
+  while (index--) {
+    code = path.charCodeAt(index)
+
+    if (code === 47 /* `/` */) {
+      // If we reached a path separator that was not part of a set of path
+      // separators at the end of the string, stop now.
+      if (unmatchedSlash) {
+        startPart = index + 1
+        break
+      }
+
+      continue
+    }
+
+    if (end < 0) {
+      // We saw the first non-path separator, mark this as the end of our
+      // extension.
+      unmatchedSlash = true
+      end = index + 1
+    }
+
+    if (code === 46 /* `.` */) {
+      // If this is our first dot, mark it as the start of our extension.
+      if (startDot < 0) {
+        startDot = index
+      } else if (preDotState !== 1) {
+        preDotState = 1
+      }
+    } else if (startDot > -1) {
+      // We saw a non-dot and non-path separator before our dot, so we should
+      // have a good chance at having a non-empty extension.
+      preDotState = -1
+    }
+  }
+
+  if (
+    startDot < 0 ||
+    end < 0 ||
+    // We saw a non-dot character immediately before the dot.
+    preDotState === 0 ||
+    // The (right-most) trimmed path component is exactly `..`.
+    (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+  ) {
+    return ''
+  }
+
+  return path.slice(startDot, end)
+}
+
+function join() {
+  var index = -1
+  var joined
+
+  while (++index < arguments.length) {
+    assertPath(arguments[index])
+
+    if (arguments[index]) {
+      joined =
+        joined === undefined
+          ? arguments[index]
+          : joined + '/' + arguments[index]
+    }
+  }
+
+  return joined === undefined ? '.' : normalize(joined)
+}
+
+// Note: `normalize` is not exposed as `path.normalize`, so some code is
+// manually removed from it.
+function normalize(path) {
+  var absolute
+  var value
+
+  assertPath(path)
+
+  absolute = path.charCodeAt(0) === 47 /* `/` */
+
+  // Normalize the path according to POSIX rules.
+  value = normalizeString(path, !absolute)
+
+  if (!value.length && !absolute) {
+    value = '.'
+  }
+
+  if (value.length && path.charCodeAt(path.length - 1) === 47 /* / */) {
+    value += '/'
+  }
+
+  return absolute ? '/' + value : value
+}
+
+// Resolve `.` and `..` elements in a path with directory names.
+function normalizeString(path, allowAboveRoot) {
+  var result = ''
+  var lastSegmentLength = 0
+  var lastSlash = -1
+  var dots = 0
+  var index = -1
+  var code
+  var lastSlashIndex
+
+  while (++index <= path.length) {
+    if (index < path.length) {
+      code = path.charCodeAt(index)
+    } else if (code === 47 /* `/` */) {
+      break
+    } else {
+      code = 47 /* `/` */
+    }
+
+    if (code === 47 /* `/` */) {
+      if (lastSlash === index - 1 || dots === 1) {
+        // Empty.
+      } else if (lastSlash !== index - 1 && dots === 2) {
+        if (
+          result.length < 2 ||
+          lastSegmentLength !== 2 ||
+          result.charCodeAt(result.length - 1) !== 46 /* `.` */ ||
+          result.charCodeAt(result.length - 2) !== 46 /* `.` */
+        ) {
+          if (result.length > 2) {
+            lastSlashIndex = result.lastIndexOf('/')
+
+            /* istanbul ignore else - No clue how to cover it. */
+            if (lastSlashIndex !== result.length - 1) {
+              if (lastSlashIndex < 0) {
+                result = ''
+                lastSegmentLength = 0
+              } else {
+                result = result.slice(0, lastSlashIndex)
+                lastSegmentLength = result.length - 1 - result.lastIndexOf('/')
+              }
+
+              lastSlash = index
+              dots = 0
+              continue
+            }
+          } else if (result.length) {
+            result = ''
+            lastSegmentLength = 0
+            lastSlash = index
+            dots = 0
+            continue
+          }
+        }
+
+        if (allowAboveRoot) {
+          result = result.length ? result + '/..' : '..'
+          lastSegmentLength = 2
+        }
+      } else {
+        if (result.length) {
+          result += '/' + path.slice(lastSlash + 1, index)
+        } else {
+          result = path.slice(lastSlash + 1, index)
+        }
+
+        lastSegmentLength = index - lastSlash - 1
+      }
+
+      lastSlash = index
+      dots = 0
+    } else if (code === 46 /* `.` */ && dots > -1) {
+      dots++
+    } else {
+      dots = -1
+    }
+  }
+
+  return result
+}
+
+function assertPath(path) {
+  if (typeof path !== 'string') {
+    throw new TypeError(
+      'Path must be a string. Received ' + JSON.stringify(path)
+    )
+  }
+}

--- a/minpath.js
+++ b/minpath.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('path')

--- a/minproc.browser.js
+++ b/minproc.browser.js
@@ -1,0 +1,10 @@
+'use strict'
+
+// Somewhat based on:
+// <https://github.com/defunctzombie/node-process/blob/master/browser.js>.
+// But I don’t think one tiny line of code can be copyrighted. 😅
+exports.cwd = cwd
+
+function cwd() {
+  return '/'
+}

--- a/minproc.js
+++ b/minproc.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = process

--- a/package.json
+++ b/package.json
@@ -32,15 +32,26 @@
     "Sindre Sorhus <sindresorhus@gmail.com>"
   ],
   "types": "types/index.d.ts",
+  "browser": {
+    "./minpath.js": "./minpath.browser.js",
+    "./minproc.js": "./minproc.browser.js"
+  },
+  "react-native": {
+    "./minpath.js": "./minpath.browser.js",
+    "./minproc.js": "./minproc.browser.js"
+  },
   "files": [
     "types/index.d.ts",
     "core.js",
-    "index.js"
+    "index.js",
+    "minpath.browser.js",
+    "minpath.js",
+    "minproc.browser.js",
+    "minproc.js"
   ],
   "dependencies": {
     "@types/unist": "^2.0.0",
     "is-buffer": "^2.0.0",
-    "replace-ext": "1.0.0",
     "unist-util-stringify-position": "^2.0.0",
     "vfile-message": "^2.0.0"
   },
@@ -87,8 +98,12 @@
       "vfile.js"
     ],
     "rules": {
+      "unicorn/explicit-length-check": "off",
       "unicorn/prefer-includes": "off",
-      "unicorn/prefer-reflect-apply": "off"
+      "unicorn/prefer-reflect-apply": "off",
+      "unicorn/prefer-number-properties": "off",
+      "max-depth": "off",
+      "complexity": "off"
     }
   },
   "remarkConfig": {

--- a/test.js
+++ b/test.js
@@ -576,8 +576,6 @@ test('p (POSIX path for browsers)', function (t) {
       }
     })
 
-    t.strictEqual(p.basename(__filename), 'test.js')
-    t.strictEqual(p.basename(__filename, '.js'), 'test')
     t.strictEqual(p.basename('.js', '.js'), '')
     t.strictEqual(p.basename(''), '')
     t.strictEqual(p.basename('/dir/basename.ext'), 'basename.ext')


### PR DESCRIPTION
Many new developers do not know how to configure webpack. When they use a package that somewhere deep down uses `path` or `process` or whatnot, through webpack 5, they mistakingly think this package does not work in browsers.

This infuriating mistake by webpack leads to superfluous work for maintainers and bigger bundles for users because polyfills add bloat.

See:
* <https://blog.sindresorhus.com/webpack-5-headache-b6ac24973bf1>
* <https://github.com/vercel/next.js/pull/16022>

Note that this change shaves off 40% from the bundle size compared to including `path` and `process`, however, it will double the bundlephobia size (because it normally does not include path/process) and will hurt folks who depend on another project that includes `path`.

Related to vfile/vfile#16.
Related to vfile/vfile#28.
Related to vfile/vfile#38.
Related to vfile/vfile#35.
Related to vfile/vfile#56.
Related to vfile/vfile#57.
Related to vfile/vfile#58.
Related to remarkjs/react-markdown#492.
Related to remarkjs/react-markdown#514.

/cc @vfile/contributors
