### PR TITLE
Add support for passing and setting file URLs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * @typedef {import('unist').Node} Node
  * @typedef {import('unist').Position} Position
  * @typedef {import('unist').Point} Point
- * @typedef {import('./minurl.js').URL} URL
+ * @typedef {import('./minurl.shared.js').URL} URL
  *
  * @typedef {'ascii'|'utf8'|'utf-8'|'utf16le'|'ucs2'|'ucs-2'|'base64'|'latin1'|'binary'|'hex'} BufferEncoding
  *   Encodings supported by the buffer class.

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
  * @typedef {import('unist').Node} Node
  * @typedef {import('unist').Position} Position
  * @typedef {import('unist').Point} Point
+ * @typedef {import('./minurl.js').URL} URL
  *
  * @typedef {'ascii'|'utf8'|'utf-8'|'utf16le'|'ucs2'|'ucs-2'|'base64'|'latin1'|'binary'|'hex'} BufferEncoding
  *   Encodings supported by the buffer class.
@@ -9,21 +10,22 @@
  *   being needed.
  *   Copied from: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2bc1d8/types/node/globals.d.ts#L174>
  *
- * @typedef {string|Uint8Array} VFileValue Contents of the file.
+ * @typedef {string|Uint8Array} VFileValue
+ *   Contents of the file.
  *   Can either be text, or a Buffer like structure.
  *   This does not directly use type `Buffer`, because it can also be used in a
  *   browser context.
  *   Instead this leverages `Uint8Array` which is the base type for `Buffer`,
  *   and a native JavaScript construct.
  *
- * @typedef {VFileValue|VFileOptions|VFile} VFileCompatible Things that can be
- *   passed to the constructor.
+ * @typedef {VFileValue|VFileOptions|VFile|URL} VFileCompatible
+ *   Things that can be passed to the constructor.
  *
  * @typedef VFileCoreOptions
  * @property {VFileValue} [value]
  * @property {string} [cwd]
  * @property {Array.<string>} [history]
- * @property {string} [path]
+ * @property {string|URL} [path]
  * @property {string} [basename]
  * @property {string} [stem]
  * @property {string} [extname]
@@ -42,6 +44,7 @@ import buffer from 'is-buffer'
 import {VFileMessage} from 'vfile-message'
 import {path} from './minpath.js'
 import {proc} from './minproc.js'
+import {urlToPath, isUrl} from './minurl.js'
 
 // Order of setting (least specific to most), we need this because otherwise
 // `{stem: 'a', path: '~/b.js'}` would throw, as a path is needed before a
@@ -74,6 +77,8 @@ export class VFile {
     } else if (typeof value === 'string' || buffer(value)) {
       // @ts-expect-error Looks like a buffer.
       options = {value}
+    } else if (isUrl(value)) {
+      options = {path: value}
     } else {
       // @ts-expect-error Looks like file or options.
       options = value
@@ -167,6 +172,8 @@ export class VFile {
 
   /**
    * Access full path (`~/index.min.js`).
+   *
+   * @returns {string}
    */
   get path() {
     return this.history[this.history.length - 1]
@@ -175,8 +182,14 @@ export class VFile {
   /**
    * Set full path (`~/index.min.js`).
    * Cannot be nullified.
+   *
+   * @param {string|URL} path
    */
   set path(path) {
+    if (isUrl(path)) {
+      path = urlToPath(path)
+    }
+
     assertNonEmpty(path, 'path')
 
     if (this.path !== path) {

--- a/lib/minurl.browser.js
+++ b/lib/minurl.browser.js
@@ -1,5 +1,9 @@
 /// <reference lib="dom" />
 
+import {isUrl} from './minurl.shared.js'
+
+export {isUrl}
+
 // See: <https://github.com/nodejs/node/blob/fcf8ba4/lib/internal/url.js>
 
 /**
@@ -63,21 +67,4 @@ function getPathFromURLPosix(url) {
   }
 
   return decodeURIComponent(pathname)
-}
-
-// Note: this is copy/pasted from `minurl.js` because otherwise DOM/Node types
-// mix up.
-/**
- * @param {unknown} fileURLOrPath
- * @returns {fileURLOrPath is URL}
- */
-export function isUrl(fileURLOrPath) {
-  return (
-    fileURLOrPath !== null &&
-    typeof fileURLOrPath === 'object' &&
-    // @ts-expect-error: indexable.
-    fileURLOrPath.href &&
-    // @ts-expect-error: indexable.
-    fileURLOrPath.origin
-  )
 }

--- a/lib/minurl.browser.js
+++ b/lib/minurl.browser.js
@@ -1,0 +1,83 @@
+/// <reference lib="dom" />
+
+// See: <https://github.com/nodejs/node/blob/fcf8ba4/lib/internal/url.js>
+
+/**
+ * @param {string|URL} path
+ */
+export function urlToPath(path) {
+  if (typeof path === 'string') {
+    path = new URL(path)
+  } else if (!isUrl(path)) {
+    /** @type {NodeJS.ErrnoException} */
+    const error = new TypeError(
+      'The "path" argument must be of type string or an instance of URL. Received `' +
+        path +
+        '`'
+    )
+    error.code = 'ERR_INVALID_ARG_TYPE'
+    throw error
+  }
+
+  if (path.protocol !== 'file:') {
+    /** @type {NodeJS.ErrnoException} */
+    const error = new TypeError('The URL must be of scheme file')
+    error.code = 'ERR_INVALID_URL_SCHEME'
+    throw error
+  }
+
+  return getPathFromURLPosix(path)
+}
+
+/**
+ * @param {URL} url
+ */
+function getPathFromURLPosix(url) {
+  if (url.hostname !== '') {
+    /** @type {NodeJS.ErrnoException} */
+    const error = new TypeError(
+      'File URL host must be "localhost" or empty on darwin'
+    )
+    error.code = 'ERR_INVALID_FILE_URL_HOST'
+    throw error
+  }
+
+  const pathname = url.pathname
+  let index = -1
+
+  while (++index < pathname.length) {
+    if (
+      pathname.charCodeAt(index) === 37 /* `%` */ &&
+      pathname.charCodeAt(index + 1) === 50 /* `2` */
+    ) {
+      const third = pathname.charCodeAt(index + 2)
+      if (third === 70 /* `F` */ || third === 102 /* `f` */) {
+        /** @type {NodeJS.ErrnoException} */
+        const error = new TypeError(
+          'File URL path must not include encoded / characters'
+        )
+        error.code = 'ERR_INVALID_FILE_URL_PATH'
+        throw error
+      }
+    }
+  }
+
+  return decodeURIComponent(pathname)
+}
+
+// Note: this is copy/pasted from `minurl.js` because otherwise DOM/Node types
+// mix up.
+/**
+ * @param {unknown} fileURLOrPath
+ * @returns {fileURLOrPath is URL}
+ */
+export function isUrl(fileURLOrPath) {
+  return (
+    fileURLOrPath !== null &&
+    typeof fileURLOrPath === 'object' &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.href &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.origin
+  )
+}

--- a/lib/minurl.js
+++ b/lib/minurl.js
@@ -1,21 +1,2 @@
-import {fileURLToPath, URL} from 'url'
-
-// `URL` export is for types.
-export {URL, fileURLToPath as urlToPath}
-
-// Note: this is copy/pasted from `minurl.browser.js` because otherwise DOM/Node
-// types mix up.
-/**
- * @param {unknown} fileURLOrPath
- * @returns {fileURLOrPath is URL}
- */
-export function isUrl(fileURLOrPath) {
-  return (
-    fileURLOrPath !== null &&
-    typeof fileURLOrPath === 'object' &&
-    // @ts-expect-error: indexable.
-    fileURLOrPath.href &&
-    // @ts-expect-error: indexable.
-    fileURLOrPath.origin
-  )
-}
+export {fileURLToPath as urlToPath} from 'url'
+export {isUrl} from './minurl.shared.js'

--- a/lib/minurl.js
+++ b/lib/minurl.js
@@ -1,0 +1,21 @@
+import {fileURLToPath, URL} from 'url'
+
+// `URL` export is for types.
+export {URL, fileURLToPath as urlToPath}
+
+// Note: this is copy/pasted from `minurl.browser.js` because otherwise DOM/Node
+// types mix up.
+/**
+ * @param {unknown} fileURLOrPath
+ * @returns {fileURLOrPath is URL}
+ */
+export function isUrl(fileURLOrPath) {
+  return (
+    fileURLOrPath !== null &&
+    typeof fileURLOrPath === 'object' &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.href &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.origin
+  )
+}

--- a/lib/minurl.shared.js
+++ b/lib/minurl.shared.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef URL
+ * @property {string} hash
+ * @property {string} host
+ * @property {string} hostname
+ * @property {string} href
+ * @property {string} origin
+ * @property {string} password
+ * @property {string} pathname
+ * @property {string} port
+ * @property {string} protocol
+ * @property {string} search
+ * @property {any} searchParams
+ * @property {string} username
+ * @property {() => string} toString
+ * @property {() => string} toJSON
+ */
+
+/**
+ * @param {unknown} fileURLOrPath
+ * @returns {fileURLOrPath is URL}
+ */
+export function isUrl(fileURLOrPath) {
+  return (
+    fileURLOrPath !== null &&
+    typeof fileURLOrPath === 'object' &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.href &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.origin
+  )
+}

--- a/lib/minurl.shared.js
+++ b/lib/minurl.shared.js
@@ -20,6 +20,7 @@
  * @param {unknown} fileURLOrPath
  * @returns {fileURLOrPath is URL}
  */
+// From: <https://github.com/nodejs/node/blob/fcf8ba4/lib/internal/url.js#L1501>
 export function isUrl(fileURLOrPath) {
   return (
     fileURLOrPath !== null &&

--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
     "atLeast": 100,
     "detail": true,
     "strict": true,
-    "ignoreCatch": true
+    "ignoreCatch": true,
+    "#": "needed `any`s",
+    "ignoreFiles": [
+      "lib/minurl.shared.d.ts"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
   "types": "index.d.ts",
   "browser": {
     "./lib/minpath.js": "./lib/minpath.browser.js",
-    "./lib/minproc.js": "./lib/minproc.browser.js"
+    "./lib/minproc.js": "./lib/minproc.browser.js",
+    "./lib/minurl.js": "./lib/minurl.browser.js"
   },
   "react-native": {
     "./lib/minpath.js": "./lib/minpath.browser.js",
-    "./lib/minproc.js": "./lib/minproc.browser.js"
+    "./lib/minproc.js": "./lib/minproc.browser.js",
+    "./lib/minurl.js": "./lib/minurl.browser.js"
   },
   "files": [
     "lib/",

--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ Defaults to `process.cwd()`.
 
 `string?` — Path of `vfile`.
 Cannot be nullified.
+You can set a file URL (a `URL` object with a `file:` protocol)
+which will be turned into a path with [`url.fileURLToPath`][file-url-to-path].
 
 ### `vfile.basename`
 
@@ -426,3 +428,5 @@ for contributing commits since!
 [encoding]: https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
 
 [buffer]: https://nodejs.org/api/buffer.html
+
+[file-url-to-path]: https://nodejs.org/api/url.html#url_url_fileurltopath_url

--- a/test.js
+++ b/test.js
@@ -255,7 +255,9 @@ test('new VFile(options?)', (t) => {
       () => {
         const u = new URL('file:')
         u.hostname = 'a.com'
+        console.log('u:', [u])
         file = new VFile(u)
+        console.log('f:', [file.path])
       },
       /File URL host must be/,
       'should not allow setting `file:` urls w/ a host'

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  */
 
+import {URL, fileURLToPath} from 'url'
 import path from 'path'
 import process from 'process'
 import {Buffer} from 'buffer'
@@ -90,6 +91,14 @@ test('new VFile(options?)', (t) => {
 
     t.deepEqual(left, right)
     t.equal(left.path, right.path)
+
+    t.end()
+  })
+
+  t.test('should accept an file URL', (t) => {
+    const url = new URL(import.meta.url)
+    const file = new VFile(url)
+    t.deepEqual(file.path, fileURLToPath(url))
 
     t.end()
   })
@@ -188,7 +197,7 @@ test('new VFile(options?)', (t) => {
   t.test('.path', (t) => {
     const fp = path.join('~', 'example.md')
     const ofp = path.join('~', 'example', 'example.txt')
-    const file = new VFile()
+    let file = new VFile()
 
     t.equal(file.path, undefined, 'should start `undefined`')
 
@@ -217,6 +226,49 @@ test('new VFile(options?)', (t) => {
       },
       /Error: `path` cannot be empty/,
       'should not remove `path`'
+    )
+
+    file = new VFile()
+    // @ts-ignore: TS doesn’t understand seem to understand setters with a
+    // different argument than the return type of the getter.
+    // So my editor shows a warning.
+    // However: actually building the project *does* not.
+    // Hence this is an ignore instead of an expect error.
+    file.path = new URL(import.meta.url)
+
+    t.deepEqual(
+      file.path,
+      fileURLToPath(import.meta.url),
+      'should support setting a URL'
+    )
+
+    t.throws(
+      () => {
+        const u = new URL('https://example.com')
+        file = new VFile(u)
+      },
+      /The URL must be of scheme file/,
+      'should not allow setting non-`file:` urls'
+    )
+
+    t.throws(
+      () => {
+        const u = new URL('file:')
+        u.hostname = 'a.com'
+        file = new VFile(u)
+      },
+      /File URL host must be/,
+      'should not allow setting `file:` urls w/ a host'
+    )
+
+    t.throws(
+      () => {
+        const u = new URL('file:')
+        u.pathname = 'a/b%2fc'
+        file = new VFile(u)
+      },
+      /File URL path must not include encoded/,
+      'should not allow setting `file:` urls w/ a slash in pathname'
     )
 
     t.end()

--- a/test.js
+++ b/test.js
@@ -251,17 +251,19 @@ test('new VFile(options?)', (t) => {
       'should not allow setting non-`file:` urls'
     )
 
-    t.throws(
-      () => {
-        const u = new URL('file:')
-        u.hostname = 'a.com'
-        console.log('u:', [u])
-        file = new VFile(u)
-        console.log('f:', [file.path])
-      },
-      /File URL host must be/,
-      'should not allow setting `file:` urls w/ a host'
-    )
+    if (process.platform !== 'win32') {
+      // Windows allows this just fine:
+      // <https://github.com/nodejs/node/blob/fcf8ba4/lib/internal/url.js#L1369>
+      t.throws(
+        () => {
+          const u = new URL('file:')
+          u.hostname = 'a.com'
+          file = new VFile(u)
+        },
+        /File URL host must be/,
+        'should not allow setting `file:` urls w/ a host'
+      )
+    }
 
     t.throws(
       () => {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This adds support for setting file URLs (WHATWG URL objects that
start with `file:`) as `path`, which will convert them to an actual
file path.
This also allows URL objects in the options and on their own as
an argument.

Related to vfile/to-vfile#17
/cc @ChristianMurphy @aduh95 

<!--do not edit: pr-->
