### PR TITLE
Upgraded dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,22 +51,22 @@
     "index.js"
   ],
   "dependencies": {
-    "@types/unist": "^2.0.0",
-    "is-buffer": "^2.0.0",
+    "@types/unist": "^2.0.6",
+    "is-buffer": "^2.0.5",
     "unist-util-stringify-position": "^3.0.0",
-    "vfile-message": "^3.0.0"
+    "vfile-message": "^3.1.0"
   },
   "devDependencies": {
-    "@types/tape": "^4.0.0",
-    "c8": "^7.0.0",
-    "prettier": "^2.0.0",
-    "remark-cli": "^10.0.0",
-    "remark-preset-wooorm": "^9.0.0",
-    "rimraf": "^3.0.0",
-    "tape": "^5.0.0",
-    "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
-    "xo": "^0.47.0"
+    "@types/tape": "^4.13.2",
+    "c8": "^7.11.0",
+    "prettier": "^2.5.1",
+    "remark-cli": "^10.0.1",
+    "remark-preset-wooorm": "^9.1.0",
+    "rimraf": "^3.0.2",
+    "tape": "^5.5.2",
+    "type-coverage": "^2.21.0",
+    "typescript": "~4.5.5",
+    "xo": "^0.48.0"
   },
   "scripts": {
     "prepack": "npm run build && npm run format",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript was throwing a type error when using vfile. It turned out, npm downloaded `@types/unist` v2.0.3 instead of the latest v2.0.6. To prevent this, I've updated all the dependencies to it latest compatible version

<!--do not edit: pr-->
