### PR TITLE
Fix paths in types for `nodenext`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,8 @@
  * @typedef {import('unist').Point} Point
  * @typedef {Record<string, unknown> & {type: string, position?: Position|undefined}} NodeLike
  * @typedef {import('./minurl.shared.js').URL} URL
- * @typedef {import('..').VFileData} VFileData
- * @typedef {import('..').VFileValue} VFileValue
+ * @typedef {import('../index.js').VFileData} VFileData
+ * @typedef {import('../index.js').VFileValue} VFileValue
  *
  * @typedef {'ascii'|'utf8'|'utf-8'|'utf16le'|'ucs2'|'ucs-2'|'base64'|'base64url'|'latin1'|'binary'|'hex'} BufferEncoding
  *   Encodings supported by the buffer class.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

In TS 4.7, the new `moduleResolution: NodeNext` mode would determine whether _declaration files_ are ESM or CJS as well. If a declaration is thought to be ESM (e.g. because the package.json contains `type: module`), all imports must have .js extensions.

We are already doing a great job and most import paths have .js extensions. The only offending one is `".."`. This blocks the build without using `skipLibCheck`, which causes https://github.com/facebook/docusaurus/pull/7586 to fail. Docusaurus is not adding `skipLibCheck` for our website because we have some hand-written declaration files, and in order to ensure their correctness we have to check them when compiling. This is the limitation of TS because TS does not allow excluding _some_ declaration files while including others.

<!--do not edit: pr-->
