### PR TITLE
Refactor to remove buffer import in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ import type {Reporter} from './lib/index.js'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
 // @ts-ignore It’s important to preserve this ignore statement. This makes sure
 // it works both with and without node types.
+// eslint-disable-next-line node/prefer-global/buffer
 type MaybeBuffer = any extends Buffer ? never : Buffer
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,11 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore It’s important to preserve this ignore statement. This makes sure
-// it works both with and without node types.
-import {Buffer} from 'buffer'
-
 import type {Reporter} from './lib/index.js'
 
 /**
  * This is the same as `Buffer` if node types are included, `never` otherwise.
  */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore It’s important to preserve this ignore statement. This makes sure
+// it works both with and without node types.
 type MaybeBuffer = any extends Buffer ? never : Buffer
 
 /**


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This can be problematic is the `buffer` package is installed. A practical example is that types published in DefinitelyTyped can’t depend on `vfile` or `unified`.

Checking the global `Buffer` works fine too.

<!--do not edit: pr-->
