### PR TITLE
fix: skip `proc.cwd()` when `cwd` is given

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ export class VFile {
      *
      * @type {string}
      */
-    this.cwd = proc.cwd()
+    this.cwd = options.cwd || proc.cwd()
 
     /**
      * Place to store custom info (default: `{}`).


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

make `VFile` skip unnecessary filesystem access for `process.cwd()` if `cwd` is already given.

due to how `VFile.cwd` works:

1. set to `process.cwd()` (`/` if browser)
2. override to `options.cwd` if exists as stated in https://github.com/vfile/vfile/pull/15#issuecomment-272976878

VFile will always request filesystem access even if it's not needed.

<!--do not edit: pr-->
