### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   ],
   "dependencies": {
     "@types/unist": "^3.0.0",
-    "unist-util-stringify-position": "^4.0.0",
     "vfile-message": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

It looks like `unist-util-stringify-position` isn't used anymore since https://github.com/vfile/vfile/commit/8def89808acc38258b8b00cac602aaf712c7286f as it replaces it with `vfile-message`, which `vfile-message` uses `unist-util-stringify-position` instead, so while this doesn't necessarily remove `unist-util-stringify-position` from `vfile`'s dependency graph, it helps prevent potential different versions installed and keeps the used dependencies concise.

<!--do not edit: pr-->
